### PR TITLE
Allow mem stats to be collected on a multiple of the process-uptime c…

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ The expected format of the xml file is as follows:
     <Path>/path/to/two.pid</Path>
     <PluginInstance>two</PluginInstance>
     <CollectMemStats>true</CollectMemStats>
+    <MemStatsInterval>60</MemStatsInterval>
   </PidFile>
 </PidFiles>
 ```
@@ -48,6 +49,7 @@ Note: It's unfortunate to need to use XML here instead of collectd's configurati
 - **`Interval`**: Specify an interval in seconds, if you want to run this at a different interval than globally
 - **`Verbose`**: if `true`, print verbose logging (`false`).
 - **`CollectMemStats`**: Add as a pid file parameter with `true` to send the RSS and Shared Memory byte sizes
+- **`MemStatsInterval`**: Add as a pid file parameter in seconds, sets the requested time interval to collect memory stats. Since the Interval parameter specifies when metrics can be collected, this value should be an even multiple of the Interval parameter.
 
 ##### Resulting metrics
 


### PR DESCRIPTION
…ollection interval

@bbeaudreault here's the PR as best as I can remember our discussion last week. The mem stats collection interval can now be set as a multiple of the specified interval for the pid tracker. If there is no specified interval or mem stats interval, the mem stats will be collected each time the process time is collected.

If the interval is specified as 20s, and the mem stats interval is specified as 30s, the mem stats will actually be collected each interval as the calculation under the covers is `interval_counter >= (pid_state.mem_stats_interval / interval)`.

There is also the option of specifying an interval multiplier but that seemed a bit more complex than was worth it and differs a bit from our discussed solutions.